### PR TITLE
Fix poor performance of get_ally_web_user

### DIFF
--- a/classes/local.php
+++ b/classes/local.php
@@ -211,7 +211,7 @@ class local {
      */
     public static function get_ally_web_user() {
         global $DB;
-        return $DB->get_record('user', ['username' => 'ally_webuser']);
+        return $DB->get_record('user', ['username' => 'ally_webuser'], ['mnethostid' => $CFG->mnet_localhost_id]);
     }
 
     /**


### PR DESCRIPTION
by using query which uses username + mnethostid where the database index does exist as outlined in https://tracker.moodle.org/browse/MDL-22877 

Or see hint at https://moodle.org/mod/forum/discuss.php?d=77625#p345604

Alternatively could use ['mnethostid' => '1'] but more hardcoded to a default.