### PR TITLE
Removed static cache of course sections due to high memory usage on l…

### DIFF
--- a/classes/componentsupport/course_component.php
+++ b/classes/componentsupport/course_component.php
@@ -154,26 +154,10 @@ class course_component extends component_base implements iface_html_content {
      * @throws \dml_exception
      */
     private function get_section_number($sectionid) {
-        global $DB;
-
-        static $sections = null; // Static caching for performance.
-
-        if (is_null($sections)) {
-            // With a 1000 courses this would take approx 516k to cache.
-            // With 10000 courses 4M to cache.
-            // With 100000 courses 32M to cache.
-            // So we are good to use static caching.
-            // http://sandbox.onlinephpfunctions.com/code/aaa8f0ed270c7e787caa6428c816fb82b11784d0.
-            $sections = $DB->get_records_menu('course_sections', null, '', 'id, section');
-        }
-
-        if (!isset($sections[$sectionid])) {
-            // Better not to throw an error because the web service might be requesting information for a section
-            // that has been deleted or something.
-            return null;
-        }
-
-        return $sections[$sectionid];
+	global $DB;
+	
+	$section = $DB->get_record('course_sections', array('id' => $sectionid), 'section');
+        return $section->section;
     }
 
     /**


### PR DESCRIPTION
This is a illustrative patch, for issue #40, I believe that make_url may need to be refactored as well if this is appropriate. 

If the static cache is required  for other code paths  than the course creation and update triggers, it may be a good idea to make this cache only populate when a large number of requests are expected. 

As it is this cache is is using over 300megabytes of ram on large sites, which can cause out of memory issues. 