### PR TITLE
Updated headers for logger methods fixing compatibilty errors

### DIFF
--- a/classes/logging/loggerbase.php
+++ b/classes/logging/loggerbase.php
@@ -48,11 +48,9 @@ abstract class loggerbase implements LoggerInterface {
     /**
      * System is unusable.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function emergency($message, array $context = []) {
+    public function emergency(string|\Stringable $message, array $context = []): void {
         // Only log if range is light or greater (Emergency|Alert|Critical).
         if ($this->logrange >= constants::RANGE_LIGHT) {
             $this->log(LogLevel::EMERGENCY, $message, $context);
@@ -64,11 +62,9 @@ abstract class loggerbase implements LoggerInterface {
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function alert($message, array $context = []) {
+    public function alert(string|\Stringable $message, array $context = []): void {
         // Only log if range is light or greater (Emergency|Alert|Critical).
         if ($this->logrange >= constants::RANGE_LIGHT) {
             $this->log(LogLevel::ALERT, $message, $context);
@@ -79,11 +75,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function critical($message, array $context = []) {
+    public function critical(string|\Stringable $message, array $context = []): void {
         // Only log if range is light or greater (Emergency|Alert|Critical).
         if ($this->logrange >= constants::RANGE_LIGHT) {
             $this->log(LogLevel::CRITICAL, $message, $context);
@@ -93,11 +87,9 @@ abstract class loggerbase implements LoggerInterface {
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function error($message, array $context = []) {
+    public function error(string|\Stringable $message, array $context = []): void {
         // Only log if range is medium or greater (Emergency|Alert|Critical|Error|Warning).
         if ($this->logrange >= constants::RANGE_MEDIUM) {
             $this->log(LogLevel::ERROR, $message, $context);
@@ -109,11 +101,9 @@ abstract class loggerbase implements LoggerInterface {
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function warning($message, array $context = []) {
+    public function warning(string|\Stringable $message, array $context = []): void {
         // Only log if range is medium (Emergency|Alert|Critical|Error|Warning).
         if ($this->logrange >= constants::RANGE_MEDIUM) {
             $this->log(LogLevel::WARNING, $message, $context);
@@ -122,11 +112,9 @@ abstract class loggerbase implements LoggerInterface {
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function notice($message, array $context = []) {
+    public function notice(string|\Stringable $message, array $context = []): void {
         // Only log if range is all - every possible type of log.
         if ($this->logrange >= constants::RANGE_ALL) {
             $this->log(LogLevel::NOTICE, $message, $context);
@@ -137,11 +125,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function info($message, array $context = []) {
+    public function info(string|\Stringable $message, array $context = []): void {
         // Only log if range is all - every possible type of log.
         if ($this->logrange >= constants::RANGE_ALL) {
             $this->log(LogLevel::INFO, $message, $context);
@@ -150,11 +136,9 @@ abstract class loggerbase implements LoggerInterface {
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    public function debug($message, array $context = []) {
+    public function debug(string|\Stringable $message, array $context = []): void {
         // Only log if range is all - every possible type of log.
         if ($this->logrange >= constants::RANGE_ALL) {
             $this->log(LogLevel::DEBUG, $message, $context);
@@ -164,9 +148,7 @@ abstract class loggerbase implements LoggerInterface {
      * Logs with an arbitrary level.
      *
      * @param mixed $level
-     * @param string $message
-     * @param array $context
-     * @return null
+     * @param mixed[] $context
      */
-    abstract public function log($level, $message, array $context = []);
+    abstract public function log($level, string|\Stringable $message, array $context = []): void;
 }

--- a/classes/logging/loggerdb.php
+++ b/classes/logging/loggerdb.php
@@ -21,6 +21,7 @@ defined('MOODLE_INTERNAL') || die();
 require_once(__DIR__ . '/../../vendor/autoload.php');
 
 use Exception;
+use Psr\Log\InvalidArgumentException;
 
 /**
  * Define database logging class.
@@ -38,11 +39,11 @@ class loggerdb extends loggerbase {
      * @param array $context
      * @return null
      */
-    public function log($level, $message, array $context = []) {
+    public function log($level, string|\Stringable $message, array $context = []): void {
         global $DB;
 
         if (!$DB->get_manager()->table_exists('tool_ally_log')) {
-            return;
+            throw new InvalidArgumentException(sprintf('The table tool_ally_log does not exist.'));
         }
 
         $message = trim($message);
@@ -94,6 +95,6 @@ class loggerdb extends loggerbase {
             'data' => serialize($context),
             'exception' => $exception,
         ];
-        return $DB->insert_record('tool_ally_log', $record);
+        $DB->insert_record('tool_ally_log', $record);
     }
 }

--- a/vendor/psr/log/Psr/Log/AbstractLogger.php
+++ b/vendor/psr/log/Psr/Log/AbstractLogger.php
@@ -14,12 +14,9 @@ abstract class AbstractLogger implements LoggerInterface
     /**
      * System is unusable.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function emergency($message, array $context = array())
+    public function emergency(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::EMERGENCY, $message, $context);
     }
@@ -30,12 +27,9 @@ abstract class AbstractLogger implements LoggerInterface
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function alert($message, array $context = array())
+    public function alert(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::ALERT, $message, $context);
     }
@@ -45,12 +39,9 @@ abstract class AbstractLogger implements LoggerInterface
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function critical($message, array $context = array())
+    public function critical(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::CRITICAL, $message, $context);
     }
@@ -59,12 +50,9 @@ abstract class AbstractLogger implements LoggerInterface
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function error($message, array $context = array())
+    public function error(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::ERROR, $message, $context);
     }
@@ -75,12 +63,9 @@ abstract class AbstractLogger implements LoggerInterface
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function warning($message, array $context = array())
+    public function warning(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::WARNING, $message, $context);
     }
@@ -88,12 +73,9 @@ abstract class AbstractLogger implements LoggerInterface
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function notice($message, array $context = array())
+    public function notice(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::NOTICE, $message, $context);
     }
@@ -103,12 +85,9 @@ abstract class AbstractLogger implements LoggerInterface
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function info($message, array $context = array())
+    public function info(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::INFO, $message, $context);
     }
@@ -116,12 +95,9 @@ abstract class AbstractLogger implements LoggerInterface
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function debug($message, array $context = array())
+    public function debug(string|\Stringable $message, array $context = []): void
     {
         $this->log(LogLevel::DEBUG, $message, $context);
     }

--- a/vendor/psr/log/Psr/Log/LoggerInterface.php
+++ b/vendor/psr/log/Psr/Log/LoggerInterface.php
@@ -22,12 +22,9 @@ interface LoggerInterface
     /**
      * System is unusable.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function emergency($message, array $context = array());
+    public function emergency(string|\Stringable $message, array $context = []): void;
 
     /**
      * Action must be taken immediately.
@@ -35,35 +32,26 @@ interface LoggerInterface
      * Example: Entire website down, database unavailable, etc. This should
      * trigger the SMS alerts and wake you up.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function alert($message, array $context = array());
+    public function alert(string|\Stringable $message, array $context = []): void;
 
     /**
      * Critical conditions.
      *
      * Example: Application component unavailable, unexpected exception.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function critical($message, array $context = array());
+    public function critical(string|\Stringable $message, array $context = []): void;
 
     /**
      * Runtime errors that do not require immediate action but should typically
      * be logged and monitored.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function error($message, array $context = array());
+    public function error(string|\Stringable $message, array $context = []): void;
 
     /**
      * Exceptional occurrences that are not errors.
@@ -71,53 +59,40 @@ interface LoggerInterface
      * Example: Use of deprecated APIs, poor use of an API, undesirable things
      * that are not necessarily wrong.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function warning($message, array $context = array());
+    public function warning(string|\Stringable $message, array $context = []): void;
 
     /**
      * Normal but significant events.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function notice($message, array $context = array());
+    public function notice(string|\Stringable $message, array $context = []): void;
 
     /**
      * Interesting events.
      *
      * Example: User logs in, SQL logs.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function info($message, array $context = array());
+    public function info(string|\Stringable $message, array $context = []): void;
 
     /**
      * Detailed debug information.
      *
-     * @param string $message
-     * @param array  $context
-     *
-     * @return void
+     * @param mixed[] $context
      */
-    public function debug($message, array $context = array());
+    public function debug(string|\Stringable $message, array $context = []): void;
 
     /**
      * Logs with an arbitrary level.
      *
-     * @param mixed  $level
-     * @param string $message
-     * @param array  $context
+     * @param mixed $level
+     * @param mixed[] $context
      *
-     * @return void
+     * @throws \Psr\Log\InvalidArgumentException
      */
-    public function log($level, $message, array $context = array());
+    public function log($level, string|\Stringable $message, array $context = []): void;
 }


### PR DESCRIPTION
Due to type strictness from PHP 8.x on some PHPUnit tests will throw a compatibility error like:
`PHP Fatal error:  Declaration of tool_ally\logging\loggerbase::emergency($message, array $context = []) must be compatible with Psr\Log\LoggerInterface::emergency(Stringable|string $message, array $context = []): void in /var/www/html/admin/tool/ally/classes/logging/loggerbase.php on line 54
`
I have updated the method headers to follow the ones in LoggerInterface.